### PR TITLE
使用 ast.literal_eval 取代原有的 request.json 来解析微信服务器返回的 json 数据

### DIFF
--- a/wechat_sdk/basic.py
+++ b/wechat_sdk/basic.py
@@ -4,6 +4,7 @@ import hashlib
 import requests
 import time
 import json
+import ast
 
 from xml.dom import minidom
 
@@ -795,7 +796,7 @@ class WechatBasic(object):
             **kwargs
         )
         r.raise_for_status()
-        response_json = r.json()
+        response_json = ast.literal_eval(r.content)
         self._check_official_error(response_json)
         return response_json
 


### PR DESCRIPTION
requests.request.json() 接口无法解析带有 emoji 字符的 json 字符串。

改为 ast.literal_eval 的方式来解析解决了这个问题。

附带有 emoji 字符的 json 字符串示例：

{'province': '\xe5\x8c\x97\xe4\xba\xac', 'city': '\xe4\xb8\xb0\xe5\x8f\xb0', 'subscribe_time': 1444454018, 'headimgurl': , 'language': 'zh_CN', 'openid': 'xxx', 'country': '\xe4\xb8\xad\xe5\x9b\xbd', 'remark': '', 'sex': 2, 'subscribe': 1, 'unionid': 'xxx', 'nickname': '\xf0\x9f\x92\x8b\x14kitty\xf0\x9f\x94\x91', 'groupid': 0}